### PR TITLE
Add some options

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ NTFY_URL=https://ntfy.sh
 NTFY_TOPIC=emails
 NTFY_AUTH_TOKEN=
 NTFY_PRIORITY=5#Message priority (1=min, 5=max)
+NTFY_CLICK_ACTION=k9mail://messages
 
 # Send the body of message to notification
 SEND_MESSAGE_BODY=true

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ NOTIFY_ALL_EMAILS=false
 # Delete Message after processing 
 DELETE_AFTER_PROCESSING=false
 
+# IMAP flag used to detect new messages
+# With \\Seen, messages will be marked as read when processed while they won't with a custom flag. Custom flag must not contain backslashes.
+IMAP_FLAG=\\Seen
+
 # Notifier
 NOTIFIER_TYPE=gotify# "gotify" or "ntfy"
 GOTIFY_URL=https://gotify.example.com

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ NTFY_TOPIC=emails
 NTFY_AUTH_TOKEN=
 NTFY_PRIORITY=5#Message priority (1=min, 5=max)
 
+# Send the body of message to notification
+SEND_MESSAGE_BODY=true
+
 # Timezone
 TZ=UTC
 

--- a/imap-idle-notify.go
+++ b/imap-idle-notify.go
@@ -76,6 +76,7 @@ var (
 
 	FromFilter            = envList("FROM_FILTER", "user@gmail.com,test@example.com")
 	DeleteAfterProcessing = envBool("DELETE_AFTER_PROCESSING", false)
+	IMAPFlag = env("IMAP_FLAG", "\\Seen")
 
 	CheckFrom = envBool("CHECK_FROM", true)
 	CheckCc   = envBool("CHECK_CC", false)
@@ -327,12 +328,12 @@ SEND:
 
 	sendNotification(sender, subject, bodyText)
 
-	// mark seen
+	// add flag
 	seqset := new(imap.SeqSet)
 	seqset.AddNum(msg.SeqNum)
-	flags := []interface{}{imap.SeenFlag}
+	flags := []interface{}{IMAPFlag}
 	if err := c.Store(seqset, imap.FormatFlagsOp(imap.AddFlags, true), flags, nil); err != nil {
-		log.Println("Failed to mark seen:", err)
+		log.Println("Failed to add flag:", err)
 	}
 
 	if DeleteAfterProcessing {
@@ -356,7 +357,7 @@ SEND:
 func fetchUnseen(c *client.Client, section *imap.BodySectionName) {
 	log.Println("Fetching unseen messages...")
 	criteria := imap.NewSearchCriteria()
-	criteria.WithoutFlags = []string{"\\Seen"}
+	criteria.WithoutFlags = []string{IMAPFlag, imap.SeenFlag}
 	ids, err := c.Search(criteria)
 	if err != nil || len(ids) == 0 {
 		return

--- a/imap-idle-notify.go
+++ b/imap-idle-notify.go
@@ -93,6 +93,7 @@ var (
 	NtfyTopic      = env("NTFY_TOPIC", "")
 	NtfyAuthToken  = env("NTFY_AUTH_TOKEN", "")
 	NtfyPriority   = envInt("NTFY_PRIORITY", 5)
+	NtfyClickAction = env("NTFY_CLICK_ACTION", "")
 
 	SendMessageBody = envBool("SEND_MESSAGE_BODY", true)
 
@@ -210,6 +211,9 @@ func sendNtfy(sender, subject, body string) {
 	req.Header.Set("Priority", strconv.Itoa(NtfyPriority))
 	if NtfyAuthToken != "" {
 		req.Header.Set("Authorization", "Bearer "+NtfyAuthToken)
+	}
+	if NtfyClickAction != "" {
+		req.Header.Set("Click", NtfyClickAction)
 	}
 
 	resp, err := httpClient.Do(req)


### PR DESCRIPTION
- I prefer to leave messages as unread until I open them in email client, so I added an option to use a custom IMAP flag for marking new messages. \Seen flag is still used by default.
- I read messages in email client, so I don't need to send the message body over notification. I added an option to disable that.
- I want to open email client right after clicking on notification, so I added an option to set Click header on ntfy notification.